### PR TITLE
Fix regex ROOT URL

### DIFF
--- a/config.php
+++ b/config.php
@@ -7,7 +7,7 @@
     $request_uri = filter_input(INPUT_SERVER, 'REQUEST_URI');
     
     $_PROTOCOL = (!is_null($https) && $https != 'off') ? 'https://' : 'http://';
-    define('ROOT',$_PROTOCOL.preg_replace('/[^a-zA-Z0-9]/i','',$http_host)
+    define('ROOT',$_PROTOCOL.preg_replace('/[^a-zA-Z0-9]\.:/i','',$http_host)
     .str_replace('\\','/',substr(dirname(__FILE__),strlen($document_root))).'/');//Returns Project basedir
     define('REQUEST', $_PROTOCOL.$server_name.$request_uri);//Returns Request complete URL
     


### PR DESCRIPTION
Se agrega '\.:' al ROOT para tener compatibilidad con Ip, subdominio y puerto en la URL.